### PR TITLE
Support light backgroud for delta diffs

### DIFF
--- a/lua/resolve/init.lua
+++ b/lua/resolve/init.lua
@@ -674,12 +674,14 @@ end
 --- @param file2 string Second file path
 --- @return string Command to run
 local function get_diff_command(file1, file2)
+  local is_light = vim.o.background == "light"
   -- Use diff with huge context (effectively unlimited) piped through delta for nice formatting
   -- delta provides intra-line highlighting and clean output with no headers
   return string.format(
-    "diff --color=always -U1000000 %s %s | delta --no-gitconfig --keep-plus-minus-markers --file-style=omit --hunk-header-style=omit",
+    "diff --color=always -U1000000 %s %s | delta --no-gitconfig --keep-plus-minus-markers --file-style=omit --hunk-header-style=omit %s",
     vim.fn.shellescape(file1),
-    vim.fn.shellescape(file2)
+    vim.fn.shellescape(file2),
+    is_light and "--light" or ""
   )
 end
 

--- a/lua/resolve/init.lua
+++ b/lua/resolve/init.lua
@@ -681,7 +681,7 @@ local function get_diff_command(file1, file2)
     "diff --color=always -U1000000 %s %s | delta --no-gitconfig --keep-plus-minus-markers --file-style=omit --hunk-header-style=omit %s",
     vim.fn.shellescape(file1),
     vim.fn.shellescape(file2),
-    is_light and "--light" or ""
+    is_light and "--light" or "--dark"
   )
 end
 


### PR DESCRIPTION
This pull request introduces a small but important usability improvement to the diff command generation logic. Now, the diff output will automatically adjust for light or dark backgrounds by passing the appropriate flag to `delta` based on the user's current Vim background setting.

- Diff output theming:
  * Updated the `get_diff_command` function in `lua/resolve/init.lua` to detect if the Vim background is set to "light" and, if so, append the `--light` flag to the `delta` command for improved readability in light-themed environments.